### PR TITLE
fix(list,rebase): sweep orphan sidecars and surface pending-restore projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `claude-vm list` shows projects with a pending restore (post-rebase, before relaunch) as `[pending restore]`. Previously these projects were invisible until their first `launch` recreated a snapshot.
+
+### Fixed
+
+- `claude-vm rebase` cleans `.ports` sidecars and orphan `.project` sidecars during its destruction phase. `.project` sidecars for projects with a backup are preserved so `list` can surface pending restores; orphans (no backup, no qcow2) accumulated in `~/.claude-vm/snapshots/` indefinitely before and are now swept.
+- `claude-vm list` skips 0-byte `.qcow2` placeholders. Interrupted snapshot creation (SIGINT/SIGTERM during `qemu-img create`) could leave an empty file behind that surfaced as a confusing `(unknown) … [stopped]` row.
+- `create_project_snapshot` traps `INT`/`TERM` and removes the partial `.qcow2` (and the sidecar it would have written) before exiting. Closes the upstream of the 0-byte qcow2 files that the `list` filter now hides.
+
 ## [0.1.0-alpha] - 2026-05-20
 
 ### Added
 
 - `claude-vm rebase` command: refreshes the shared base image (Claude Code, OS packages, kernel) while preserving each project VM's persistent state by extracting `~/.claude/`, `~/.claude.json`, `~/.gitconfig`, and `~/.config/gh/` to a per-project backup directory, rebuilding the base from upstream, and lazy-restoring the extracted state on the project's next launch.
 
+[Unreleased]: https://github.com/shudza/claude-vm/compare/v0.1.0-alpha...HEAD
 [0.1.0-alpha]: https://github.com/shudza/claude-vm/releases/tag/v0.1.0-alpha

--- a/claude-vm
+++ b/claude-vm
@@ -453,32 +453,49 @@ cmd_list() {
 
     if [[ -d "$SNAPSHOTS_DIR" ]]; then
         local count=0
-        for snap in "$SNAPSHOTS_DIR"/*.qcow2; do
-            if [[ -f "$snap" ]]; then
-                local hash size project_dir_label status_label
-                hash=$(basename "$snap" .qcow2)
-                size=$(du -h "$snap" | cut -f1)
+        local hash snap project_file backup_dir pid_file
+        local label size status
+        while IFS= read -r hash; do
+            [[ -z "$hash" ]] && continue
+            snap="$SNAPSHOTS_DIR/${hash}.qcow2"
+            project_file="$SNAPSHOTS_DIR/${hash}.project"
+            backup_dir="$BACKUPS_DIR/${hash}"
+            pid_file="$RUN_DIR/${hash}/qemu.pid"
 
-                # Read project directory from sidecar file
-                local project_file="$SNAPSHOTS_DIR/${hash}.project"
-                if [[ -f "$project_file" ]]; then
-                    project_dir_label="$(cat "$project_file")"
-                else
-                    project_dir_label="(unknown)"
-                fi
-
-                # Check if VM is running for this snapshot
-                if [[ -f "$RUN_DIR/$hash/qemu.pid" ]] && kill -0 "$(cat "$RUN_DIR/$hash/qemu.pid" 2>/dev/null)" 2>/dev/null; then
-                    status_label="RUNNING"
-                else
-                    status_label="stopped"
-                fi
-
-                echo "  $project_dir_label"
-                echo "    $hash  $size  [$status_label]"
-                (( ++count ))
+            if [[ -f "$pid_file" ]] && kill -0 "$(cat "$pid_file" 2>/dev/null)" 2>/dev/null; then
+                status="RUNNING"
+                size="$(du -h "$snap" 2>/dev/null | cut -f1)"
+                [[ -z "$size" ]] && size="—"
+            elif [[ -f "$snap" && -s "$snap" ]]; then
+                status="stopped"
+                size="$(du -h "$snap" | cut -f1)"
+            elif [[ -d "$backup_dir" ]]; then
+                status="pending restore"
+                size="—"
+            else
+                continue
             fi
-        done
+
+            if [[ -f "$project_file" ]]; then
+                label="$(cat "$project_file")"
+            else
+                label="(unknown)"
+            fi
+
+            echo "  $label"
+            echo "    $hash  $size  [$status]"
+            (( ++count ))
+        done < <(
+            {
+                for f in "$SNAPSHOTS_DIR"/*.qcow2 "$SNAPSHOTS_DIR"/*.project; do
+                    [[ -f "$f" ]] || continue
+                    b="${f##*/}"
+                    b="${b%.qcow2}"
+                    b="${b%.project}"
+                    echo "$b"
+                done
+            } | sort -u
+        )
 
         if (( count == 0 )); then
             echo "  (none)"

--- a/lib/rebase.sh
+++ b/lib/rebase.sh
@@ -411,10 +411,21 @@ EOF
     fi
 
     ui_info "Removing old snapshots..."
-    local snap
     if [[ -d "$SNAPSHOTS_DIR" ]]; then
-        for snap in "$SNAPSHOTS_DIR"/*.qcow2; do
-            [[ -f "$snap" ]] && rm -f "$snap"
+        local f hash
+        # qcow2 + ports are always wiped: snapshots are unbootable against
+        # the new base, ports are transient.
+        for f in "$SNAPSHOTS_DIR"/*.qcow2 "$SNAPSHOTS_DIR"/*.ports; do
+            [[ -f "$f" ]] && rm -f "$f"
+        done
+        # .project sidecar survives only if the project has a backup waiting
+        # — that's what lets `claude-vm list` surface the pending restore
+        # before the user relaunches. Orphans (no backup) are swept.
+        for f in "$SNAPSHOTS_DIR"/*.project; do
+            [[ -f "$f" ]] || continue
+            hash="${f##*/}"
+            hash="${hash%.project}"
+            [[ -d "$BACKUPS_DIR/$hash" ]] || rm -f "$f"
         done
     fi
 

--- a/lib/snapshot.sh
+++ b/lib/snapshot.sh
@@ -58,16 +58,21 @@ create_project_snapshot() {
     echo "  Base: $base_img"
     echo "  Snapshot: $snap_path"
 
-    # Create QCOW2 image backed by the base image (copy-on-write)
-    # -b sets the backing file, -F specifies the backing file format
+    # Catch SIGINT/SIGTERM mid-create. qemu-img opens the target file before
+    # writing the qcow2 header, so a signal during creation can leave a 0-byte
+    # placeholder that pollutes `claude-vm list` as a (unknown) entry.
+    local sidecar_path="$SNAPSHOTS_DIR/${hash}.project"
+    trap 'rm -f "$snap_path" "$sidecar_path"; trap - INT TERM; return 130' INT TERM
+
     if ! qemu-img create -f qcow2 -b "$base_img" -F qcow2 "$snap_path"; then
         echo "ERROR: Failed to create linked snapshot" >&2
         rm -f "$snap_path"
+        trap - INT TERM
         return 1
     fi
 
-    # Store project directory path as sidecar metadata (for cmd_list)
-    echo "$project_dir" > "$SNAPSHOTS_DIR/${hash}.project"
+    echo "$project_dir" > "$sidecar_path"
+    trap - INT TERM
 
     echo "  Snapshot created ($(du -h "$snap_path" | cut -f1) initial — grows on write)"
     return 0

--- a/tests/test_list.sh
+++ b/tests/test_list.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test_list.sh — Unit tests for cmd_list (claude-vm list)
+#
+# Exercises the snapshot iteration logic: real snapshots show their sidecar
+# label, sidecar-less snapshots show (unknown), 0-byte placeholders are
+# filtered out entirely (orphan partials from interrupted creation).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { echo "  PASS: $1"; (( TESTS_PASSED++ )); (( TESTS_RUN++ )); }
+fail() { echo "  FAIL: $1 — $2"; (( TESTS_FAILED++ )); (( TESTS_RUN++ )); }
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+_init() {
+    export CLAUDE_VM_DIR="$TEST_DIR/$1"
+    export CLAUDE_VM_CONFIG="$CLAUDE_VM_DIR/config"
+    mkdir -p "$CLAUDE_VM_DIR"
+    # Re-source config.sh so path constants pick up the new CLAUDE_VM_DIR
+    source "$PROJECT_DIR/lib/config.sh"
+    set +euo pipefail
+    load_config
+    ensure_dirs
+}
+
+# Mock base_image_exists so cmd_list's base-image block doesn't crash on a
+# missing or fake image.
+base_image_exists() { [[ -f "$(base_image_path)" ]]; }
+
+# Extract cmd_list from the claude-vm binary so we can call it in-process.
+eval "$(sed -n '/^cmd_list()/,/^}/p' "$PROJECT_DIR/claude-vm")"
+
+# ── Test 1: real snapshot with sidecar shows project path ───────────────────
+
+test_list_shows_sidecar_label() {
+    echo "--- Test 1: list shows project path from sidecar ---"
+    _init "list-sidecar"
+
+    local project="/tmp/proj-list-sidecar-$$"
+    local hash
+    hash="$(project_hash "$project")"
+    echo "fake qcow2 content" > "$SNAPSHOTS_DIR/${hash}.qcow2"
+    echo "$project" > "$SNAPSHOTS_DIR/${hash}.project"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    if echo "$output" | grep -qF "$project"; then
+        pass "project path appears in output"
+    else
+        fail "list sidecar" "expected '$project' in output: $output"
+    fi
+}
+
+# ── Test 2: 0-byte qcow2 (orphan partial) is filtered out ───────────────────
+
+test_list_skips_empty_qcow2() {
+    echo "--- Test 2: list skips 0-byte qcow2 placeholders ---"
+    _init "list-empty"
+
+    # 0-byte file — simulates an interrupted snapshot creation
+    : > "$SNAPSHOTS_DIR/deadbeef0000.qcow2"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    if echo "$output" | grep -qF "deadbeef0000"; then
+        fail "list empty filter" "0-byte qcow2 appeared in output: $output"
+    elif echo "$output" | grep -qF "(unknown)"; then
+        fail "list empty filter" "0-byte qcow2 surfaced as (unknown): $output"
+    else
+        pass "0-byte qcow2 is hidden"
+    fi
+}
+
+# ── Test 3: mix of real + empty — only the real one is shown ────────────────
+
+test_list_mix_real_and_empty() {
+    echo "--- Test 3: list shows real snapshot but hides 0-byte siblings ---"
+    _init "list-mix"
+
+    local project="/tmp/proj-list-mix-$$"
+    local hash
+    hash="$(project_hash "$project")"
+    echo "qcow2 contents" > "$SNAPSHOTS_DIR/${hash}.qcow2"
+    echo "$project" > "$SNAPSHOTS_DIR/${hash}.project"
+
+    # Two orphan 0-byte siblings
+    : > "$SNAPSHOTS_DIR/aaaaaaaaaaaa.qcow2"
+    : > "$SNAPSHOTS_DIR/bbbbbbbbbbbb.qcow2"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    local ok=true
+    echo "$output" | grep -qF "$project"     || { fail "real shown"  "missing $project"; ok=false; }
+    echo "$output" | grep -qF "aaaaaaaaaaaa" && { fail "empty hidden" "aaaaaaaaaaaa leaked"; ok=false; }
+    echo "$output" | grep -qF "bbbbbbbbbbbb" && { fail "empty hidden" "bbbbbbbbbbbb leaked"; ok=false; }
+    echo "$output" | grep -qF "(unknown)"    && { fail "no unknowns" "(unknown) appeared: $output"; ok=false; }
+
+    $ok && pass "real snapshot shown, both 0-byte siblings hidden"
+}
+
+# ── Test 4: pending restore (sidecar + backup, no qcow2) ────────────────────
+
+test_list_shows_pending_restore() {
+    echo "--- Test 4: list shows [pending restore] for sidecar+backup with no qcow2 ---"
+    _init "list-pending"
+
+    local project="/tmp/proj-list-pending-$$"
+    local hash
+    hash="$(project_hash "$project")"
+
+    # State left by a successful rebase: sidecar kept, qcow2 gone, backup waiting.
+    echo "$project" > "$SNAPSHOTS_DIR/${hash}.project"
+    mkdir -p "$BACKUPS_DIR/${hash}/.claude"
+    echo "data" > "$BACKUPS_DIR/${hash}/.claude/settings.json"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    local ok=true
+    echo "$output" | grep -qF "$project"          || { fail "project label"   "missing $project"; ok=false; }
+    echo "$output" | grep -qF "pending restore"   || { fail "status label"    "missing [pending restore]"; ok=false; }
+    echo "$output" | grep -qF "$hash"             || { fail "hash shown"      "missing $hash"; ok=false; }
+
+    $ok && pass "pending-restore project surfaces with sidecar label + [pending restore]"
+}
+
+# ── Test 5: orphan sidecar without backup is hidden ─────────────────────────
+
+test_list_hides_orphan_sidecar() {
+    echo "--- Test 5: list ignores sidecar with no qcow2 and no backup ---"
+    _init "list-orphan-sidecar"
+
+    # Sidecar from an old destroyed project — no qcow2, no backup
+    echo "/tmp/gone" > "$SNAPSHOTS_DIR/deadbeefdead.project"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    if echo "$output" | grep -qF "deadbeefdead"; then
+        fail "orphan sidecar leaked" "hash appeared: $output"
+    elif echo "$output" | grep -qF "/tmp/gone"; then
+        fail "orphan sidecar leaked" "label appeared: $output"
+    else
+        pass "orphan sidecar without backup is hidden"
+    fi
+}
+
+# ── Test 6: empty dir yields "(none)" ───────────────────────────────────────
+
+test_list_empty_dir() {
+    echo "--- Test 4: list prints (none) for empty snapshots dir ---"
+    _init "list-none"
+
+    local output
+    output="$(cmd_list 2>&1)"
+
+    if echo "$output" | grep -q "(none)"; then
+        pass "empty dir shows (none)"
+    else
+        fail "list empty" "expected '(none)' marker, got: $output"
+    fi
+}
+
+# ── Run all tests ───────────────────────────────────────────────────────────
+
+echo "=== claude-vm list tests ==="
+echo ""
+
+test_list_shows_sidecar_label
+test_list_skips_empty_qcow2
+test_list_mix_real_and_empty
+test_list_shows_pending_restore
+test_list_hides_orphan_sidecar
+test_list_empty_dir
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed, $TESTS_RUN total ==="
+
+(( TESTS_FAILED > 0 )) && exit 1
+exit 0

--- a/tests/test_rebase.sh
+++ b/tests/test_rebase.sh
@@ -369,9 +369,68 @@ test_cmd_rebase_destroys_and_rebuilds() {
     $_build_called                                || { fail "rebuild" "build_base_image not called"; ok=false; }
     [[ -f "$(base_image_path)" ]]                 || { fail "new base" "missing"; ok=false; }
     [[ -f "$SNAPSHOTS_DIR/$(project_hash "$proj").project" ]] \
-                                                  || { fail "sidecar preserved" ".project removed"; ok=false; }
+                                                  && { fail "sidecar wiped" ".project still present after rebase"; ok=false; }
 
-    $ok && pass "snapshots removed, sidecar kept, base rebuilt"
+    $ok && pass "snapshots + sidecars removed, base rebuilt"
+
+    teardown_test_env
+}
+
+# ── 12b: rebase preserves sidecars for pending restores, drops the rest ─────
+
+test_cmd_rebase_sidecar_lifecycle() {
+    echo "--- Test 12b: rebase keeps sidecars w/ pending restore, drops orphans ---"
+    setup_test_env
+
+    local proj_pending="/tmp/proj-pending-restore-$$"
+    local proj_force="/tmp/proj-force-drop-$$"
+    register_project "$proj_pending"
+    register_project "$proj_force"
+    : > "$(base_image_path)"
+
+    # Orphan sidecars (older versions / interrupted destroys — no backup, no qcow2)
+    echo "/tmp/gone-project-a" > "$SNAPSHOTS_DIR/aaaaaaaaaaaa.project"
+    echo "8080,3000"           > "$SNAPSHOTS_DIR/aaaaaaaaaaaa.ports"
+    echo "/tmp/gone-project-b" > "$SNAPSHOTS_DIR/bbbbbbbbbbbb.project"
+
+    # Orphan 0-byte qcow2 — what the user saw as (unknown).
+    : > "$SNAPSHOTS_DIR/cccccccccccc.qcow2"
+
+    # proj_pending extracts successfully → backup written → sidecar kept
+    # proj_force fails extraction → no backup → sidecar dropped
+    _extract_one_vm() {
+        if [[ "$1" == "$proj_force" ]]; then
+            return 1
+        fi
+        local bd
+        bd="$(project_backup_dir "$1")"
+        mkdir -p "$bd/.claude"
+        echo "data" > "$bd/.claude/settings.json"
+        return 0
+    }
+    build_base_image() { echo "new base" > "$(base_image_path)"; }
+
+    cmd_rebase --yes --force >/dev/null 2>&1
+
+    local hp hf
+    hp="$(project_hash "$proj_pending")"
+    hf="$(project_hash "$proj_force")"
+
+    local ok=true
+    # Orphans wiped
+    [[ -f "$SNAPSHOTS_DIR/aaaaaaaaaaaa.project" ]] && { fail "orphan .project a" "still present"; ok=false; }
+    [[ -f "$SNAPSHOTS_DIR/aaaaaaaaaaaa.ports" ]]   && { fail "orphan .ports a"   "still present"; ok=false; }
+    [[ -f "$SNAPSHOTS_DIR/bbbbbbbbbbbb.project" ]] && { fail "orphan .project b" "still present"; ok=false; }
+    [[ -f "$SNAPSHOTS_DIR/cccccccccccc.qcow2" ]]   && { fail "empty qcow2"       "still present"; ok=false; }
+    # qcow2 of registered projects always gone
+    [[ -f "$SNAPSHOTS_DIR/${hp}.qcow2" ]]          && { fail "pending qcow2"     "still present"; ok=false; }
+    [[ -f "$SNAPSHOTS_DIR/${hf}.qcow2" ]]          && { fail "force-drop qcow2"  "still present"; ok=false; }
+    # Pending-restore sidecar preserved so `list` can show it before relaunch
+    [[ -f "$SNAPSHOTS_DIR/${hp}.project" ]]        || { fail "pending sidecar"   "dropped despite backup"; ok=false; }
+    # Force-dropped project has no backup → sidecar removed
+    [[ -f "$SNAPSHOTS_DIR/${hf}.project" ]]        && { fail "force sidecar"     "kept without backup"; ok=false; }
+
+    $ok && pass "sidecars: orphans wiped, pending kept, force-dropped wiped"
 
     teardown_test_env
 }
@@ -505,6 +564,7 @@ test_rebase_requires_base
 test_rebase_bad_flag
 test_cmd_rebase_extracts_into_backup_dir
 test_cmd_rebase_destroys_and_rebuilds
+test_cmd_rebase_sidecar_lifecycle
 test_cmd_rebase_aborts_on_failure
 test_cmd_rebase_force_drops_failed
 test_restore_consumes_backup

--- a/tests/test_snapshot_isolation.sh
+++ b/tests/test_snapshot_isolation.sh
@@ -283,6 +283,75 @@ test_snapshot_cow_size() {
 }
 
 # ──────────────────────────────────────────────
+# Test 8: SIGTERM during snapshot creation leaves no 0-byte file behind
+# ──────────────────────────────────────────────
+test_no_partial_on_signal() {
+    echo "Test 8: SIGTERM during snapshot creation cleans up partial qcow2"
+
+    setup_base_image
+
+    local project_dir="$TEST_DIR/fake-project-signal"
+    mkdir -p "$project_dir"
+    local snap_path hash sidecar
+    snap_path="$(project_snapshot_path "$project_dir")"
+    hash="$(project_hash "$project_dir")"
+    sidecar="$SNAPSHOTS_DIR/${hash}.project"
+
+    # Run create in a backgrounded subshell. The mocked qemu-img writes an
+    # empty target file (mirroring real qemu-img which opens-then-fills) and
+    # then sleeps long enough for the parent to send SIGTERM. Without a trap
+    # in create_project_snapshot, the partial file outlives the script.
+    (
+        qemu-img() {
+            case "$1" in
+                create)
+                    local target="${@: -1}"
+                    : > "$target"
+                    sleep 10
+                    ;;
+                *) command qemu-img "$@" ;;
+            esac
+        }
+        create_project_snapshot "$project_dir" >/dev/null 2>&1
+    ) &
+    local sub_pid=$!
+
+    # Wait for the partial file to appear
+    local waited=0
+    while (( waited < 50 )) && [[ ! -e "$snap_path" ]]; do
+        sleep 0.1
+        (( waited++ )) || true
+    done
+
+    if [[ ! -e "$snap_path" ]]; then
+        kill -KILL "$sub_pid" 2>/dev/null || true
+        wait "$sub_pid" 2>/dev/null || true
+        fail "test setup: partial qcow2 never appeared, can't exercise signal path"
+        return
+    fi
+
+    # Now send SIGTERM and let the trap clean up
+    kill -TERM "$sub_pid" 2>/dev/null || true
+    wait "$sub_pid" 2>/dev/null || true
+
+    if [[ -e "$snap_path" ]]; then
+        local sz
+        sz="$(stat -c %s "$snap_path" 2>/dev/null || echo "?")"
+        fail "partial qcow2 left behind after SIGTERM ($sz bytes)"
+        rm -f "$snap_path"
+    else
+        pass "trap removed partial qcow2 on SIGTERM"
+    fi
+
+    if [[ -e "$sidecar" ]]; then
+        fail "sidecar leaked despite SIGTERM"
+        rm -f "$sidecar"
+    else
+        pass "no .project sidecar written on SIGTERM"
+    fi
+}
+
+# ──────────────────────────────────────────────
 # Run all tests
 # ──────────────────────────────────────────────
 echo "=== claude-vm snapshot isolation tests ==="
@@ -301,6 +370,8 @@ echo ""
 test_verify_snapshot
 echo ""
 test_snapshot_cow_size
+echo ""
+test_no_partial_on_signal
 echo ""
 
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Closes #5

## Summary
- Sweep orphan `.project`/`.ports` sidecars during `rebase` (preserve `.project` when a backup exists for that project)
- Add INT/TERM trap to `create_project_snapshot` so a Ctrl-C mid-create no longer leaves 0-byte `*.qcow2` placeholders
- `cmd_list` now unions qcow2s with sidecars and renders a new `[pending restore]` status, so post-rebase projects appear immediately without needing a relaunch

## Test plan
- [ ] `make test-unit` passes
- [ ] `bash tests/test_rebase.sh` passes (covers orphan sidecar sweep + preservation when backup exists)
- [ ] `bash tests/test_snapshot_isolation.sh` passes (covers INT/TERM trap behavior)
- [ ] `bash tests/test_list.sh` passes (covers `[pending restore]` rendering and 0-byte qcow2 skip)
- [ ] Manual: after a rebase with a project mid-restore, `claude-vm list` shows it as `[pending restore]` instead of hiding it
- [ ] Manual: Ctrl-C during `claude-vm` launch on a fresh project leaves no 0-byte qcow2 in `~/.claude-vm/snapshots/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)