### PR TITLE
Fix missing host dependency checks (#7) + REBASE_BACKUP_PATHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `REBASE_BACKUP_PATHS` config key: comma-separated list of extra guest paths (absolute like `/etc/ssh` or home-relative like `~/.ssh`) that `claude-vm rebase` backs up and restores on next launch, alongside the built-in set. Unlike the built-ins, these are synced as root (`sudo rsync`) with permissions and ownership preserved (`--fake-super` on the host side). Extracted paths are recorded in a `.rebase-paths` manifest inside the backup so a config edit between rebase and relaunch can't misroute the restore; restore is an overlay (no `--delete`).
+
 ## [0.1.1-alpha] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `jq` is now checked by `check_build_prerequisites` and listed in the README requirements. It has always been required (it parses `qemu-img info --output=json`), but a host without it only found out at the end of a base build. ([#7](https://github.com/shudza/claude-vm/issues/7))
+- `newuidmap`/`newgidmap` are checked before virtiofsd is started, and listed in the README requirements. Rust virtiofsd shells out to them for its unprivileged user namespace; on Debian/Ubuntu they ship in the separate `uidmap` package, which is not installed by default. ([#7](https://github.com/shudza/claude-vm/issues/7))
 - `REBASE_BACKUP_PATHS` config key: comma-separated list of extra guest paths (absolute like `/etc/ssh` or home-relative like `~/.ssh`) that `claude-vm rebase` backs up and restores on next launch, alongside the built-in set. Unlike the built-ins, these are synced as root (`sudo rsync`) with permissions and ownership preserved (`--fake-super` on the host side). Extracted paths are recorded in a `.rebase-paths` manifest inside the backup so a config edit between rebase and relaunch can't misroute the restore; restore is an overlay (no `--delete`).
+
+### Fixed
+
+- `start_virtiofsd` verifies that the daemon is still running instead of only checking that the socket file exists. virtiofsd binds its socket before finishing sandbox setup, so a daemon that died afterwards left the socket behind, passed the check, and surfaced as an unrelated-looking QEMU error (`Failed to connect to '…/virtiofs.sock': Connection refused`). Failures now report the tail of `virtiofsd.log`. ([#7](https://github.com/shudza/claude-vm/issues/7))
+- A failure to read the provisioned image size is no longer reported as `provisioned image is suspiciously small (0MB)`. `qemu-img info | jq` errors were swallowed and collapsed into a size of 0, which pointed at a provisioning bug that didn't exist. ([#7](https://github.com/shudza/claude-vm/issues/7))
 
 ## [0.1.1-alpha] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,26 @@ Claude Code works best with `--dangerously-skip-permissions`, but running an AI 
 - Linux with KVM support (`/dev/kvm` accessible)
 - QEMU (`qemu-system-x86_64`, `qemu-img`)
 - virtiofsd
+- `newuidmap` / `newgidmap` — virtiofsd uses them to build its user namespace
+  when run unprivileged (Debian/Ubuntu: `uidmap` package; elsewhere part of `shadow`)
 - An ISO creation tool (`genisoimage`, `mkisofs`, or `xorrisofs`)
-- curl, rsync
+- curl, rsync, jq
 
 ### Install dependencies
 
 **Arch / CachyOS:**
 ```bash
-sudo pacman -S qemu-full virtiofsd cdrtools curl rsync
+sudo pacman -S qemu-full virtiofsd cdrtools curl rsync jq
 ```
 
 **Ubuntu / Debian:**
 ```bash
-sudo apt install qemu-system-x86 qemu-utils virtiofsd genisoimage curl rsync
+sudo apt install qemu-system-x86 qemu-utils virtiofsd genisoimage curl rsync jq uidmap
+```
+
+**Fedora:**
+```bash
+sudo dnf install qemu-system-x86 qemu-img virtiofsd genisoimage curl rsync jq shadow-utils
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ claude-vm config set VM_USER alice
 claude-vm config set SSH_PORT_BASE 10022
 claude-vm config set FORWARD_PORTS "8080,3000:3000"   # per-project
 claude-vm config set CLAUDE_ARGS "--dangerously-skip-permissions --model sonnet"
+claude-vm config set REBASE_BACKUP_PATHS "/etc/ssh,~/.ssh"   # extra paths kept through rebase
 ```
 
 Or edit directly:
@@ -192,6 +193,8 @@ claude-vm destroy --all   # Removes base image + all snapshots
 ```bash
 claude-vm rebase   # Extracts state, rebuilds base, restores on next launch
 ```
+
+Rebase preserves `~/.claude/`, `~/.claude.json`, `~/.gitconfig`, `~/.config/gh/` by default. Add arbitrary guest paths (synced as root with permissions preserved) via `REBASE_BACKUP_PATHS` — see [docs/usage.md](docs/usage.md#claude-vm-rebase).
 
 ## Contributing
 

--- a/claude-vm
+++ b/claude-vm
@@ -123,6 +123,7 @@ cmd_config() {
                 SSH_PORT_BASE) echo "$SSH_PORT_BASE" ;;
                 FORWARD_PORTS) get_project_forward_ports "$PWD" ;;
                 CLAUDE_ARGS) echo "$CLAUDE_ARGS" ;;
+                REBASE_BACKUP_PATHS) echo "$REBASE_BACKUP_PATHS" ;;
                 BASE_IMAGE_URL) echo "$BASE_IMAGE_URL" ;;
                 BASE_IMAGE_NAME) echo "$BASE_IMAGE_NAME" ;;
                 *)
@@ -155,7 +156,7 @@ DEFAULTS
             echo "  get KEY           Get a config value"
             echo "  edit              Open config file in \$EDITOR"
             echo ""
-            echo "Keys: FLAVOR, VM_USER, VM_RAM, VM_CPUS, SSH_PORT_BASE, BASE_IMAGE_URL, BASE_IMAGE_NAME, FORWARD_PORTS"
+            echo "Keys: FLAVOR, VM_USER, VM_RAM, VM_CPUS, SSH_PORT_BASE, BASE_IMAGE_URL, BASE_IMAGE_NAME, FORWARD_PORTS, CLAUDE_ARGS, REBASE_BACKUP_PATHS"
             ;;
         *)
             echo "Unknown config subcommand: $subcmd" >&2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,10 +70,10 @@ All output goes to `~/.claude-vm/run/<hash>/launch.log`. The user sees a spinner
 
 `claude-vm rebase` rebuilds the base image from the latest cloud image while preserving per-VM state:
 
-1. **Extract:** For each project, boot the VM headless (no virtiofs — `workspace.mount` uses `nofail`), rsync persistent state (`~/.claude/`, `~/.gitconfig`, `~/.config/gh/`) to `~/.claude-vm/backups/<hash>/`, fast shutdown
+1. **Extract:** For each project, boot the VM headless (no virtiofs — `workspace.mount` uses `nofail`), rsync persistent state (`~/.claude/`, `~/.gitconfig`, `~/.config/gh/`) to `~/.claude-vm/backups/<hash>/`, fast shutdown. Paths from `REBASE_BACKUP_PATHS` are copied in a second pass as root (`--rsync-path="sudo rsync"`) with perms/ownership preserved via `--fake-super` xattrs, and recorded in a `.rebase-paths` manifest inside the backup
 2. **Destroy:** Remove all `<hash>.qcow2` snapshots (preserve `.project` and `.ports` sidecars), remove old base image and cached cloud image
 3. **Rebuild:** `build_base_image()` downloads the latest cloud image and provisions from scratch
-4. **Restore (lazy):** On next `launch_vm()`, if `~/.claude-vm/backups/<hash>/` exists, rsync its contents into the freshly created VM, then remove the backup directory
+4. **Restore (lazy):** On next `launch_vm()`, if `~/.claude-vm/backups/<hash>/` exists, rsync its contents into the freshly created VM, then remove the backup directory. Manifest paths are pushed as root with perms/ownership restored, as an overlay (no `--delete`) so files the fresh image ships survive
 
 The backup directory itself is the "pending restore" marker — no separate state file needed.
 
@@ -135,6 +135,8 @@ Only **user-scoped** MCP servers carry over automatically. For a server you want
       .claude.json          Theme, onboarding state
       .config/gh/           GitHub CLI auth tokens
       .gitconfig            Git identity
+      .rebase-paths         Manifest of extracted REBASE_BACKUP_PATHS entries
+      _abs/                 Absolute REBASE_BACKUP_PATHS entries (/etc/ssh → _abs/etc/ssh)
   cloud-init/
     user-data              Generated cloud-init config
     meta-data

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -112,7 +112,7 @@ Unit tests (`tests/test_*.sh`, excluding `test_e2e.sh`) mock QEMU and virtiofsd 
 
 `tests/test_e2e.sh` exercises the full CLI workflow — `claude-vm build`, `launch`, `stop`, `reset`, `destroy` — against real QEMU VMs with virtiofs.
 
-**Requirements:** A KVM-capable Linux host with nested virtualization. The test VM spawns its own nested QEMU VMs. Required tools: `qemu-system-x86_64`, `qemu-img`, `virtiofsd`, an ISO tool (`genisoimage`/`mkisofs`/`xorrisofs`), `curl`, `socat`, `rsync`, `jq`, `ssh`. If any prerequisite is missing, the suite skips (exit 0).
+**Requirements:** A KVM-capable Linux host with nested virtualization. The test VM spawns its own nested QEMU VMs. Required tools: `qemu-system-x86_64`, `qemu-img`, `virtiofsd`, an ISO tool (`genisoimage`/`mkisofs`/`xorrisofs`), `curl`, `socat`, `rsync`, `jq`, `ssh`, `newuidmap`/`newgidmap`. If any prerequisite is missing, the suite skips (exit 0) — so an E2E run can never catch a host dependency the suite itself requires. Host-dependency gaps belong in the unit tests instead.
 
 **Recommended way to run:** Inside a claude-vm instance, which already has all deps and nested KVM:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,7 +101,15 @@ claude-vm rebase --force              # Drop broken VM snapshots that can't be e
 4. Downloads and provisions a fresh base image
 5. On the next launch, each project gets a fresh snapshot from the new base, and the extracted state is restored
 
-**State preserved:** `~/.claude/` (settings, credentials, plugins, skills), `~/.claude.json`, `~/.gitconfig`, `~/.config/gh/`. Everything else in each VM is lost.
+**State preserved:** `~/.claude/` (settings, credentials, plugins, skills), `~/.claude.json`, `~/.gitconfig`, `~/.config/gh/`, plus any extra paths configured via `REBASE_BACKUP_PATHS` (see below). Everything else in each VM is lost.
+
+**Extra backup paths:** persist arbitrary guest paths through a rebase with a comma-separated list of absolute (`/etc/ssh`) or home-relative (`~/.ssh`) paths:
+
+```bash
+claude-vm config set REBASE_BACKUP_PATHS "/etc/ssh,~/.ssh"
+```
+
+Unlike the built-in set, these are synced with `sudo rsync` and keep permissions and ownership (root-owned files included). The extracted paths are recorded in a manifest inside the backup, so changing `REBASE_BACKUP_PATHS` between a rebase and the next launch doesn't affect what gets restored. Restore is an overlay (no `--delete`): backed-up files overwrite same-named files in the fresh image, but files the new image ships that aren't in the backup are untouched. Prefer narrow paths (`/etc/ssh/sshd_config`) over broad ones (`/etc`) — restoring a whole system directory wholesale over a freshly provisioned image is your responsibility. Preserving root ownership in the host-side backup uses rsync `--fake-super`, which requires user-xattr support on the filesystem holding `~/.claude-vm/backups/`.
 
 **State restore is lazy:** extracted state sits in `~/.claude-vm/backups/<hash>/` until the project is next launched, at which point it is rsynced into the fresh VM and the backup directory is removed.
 
@@ -234,6 +242,7 @@ CLAUDE_ARGS="--dangerously-skip-permissions --model sonnet"
 | `BASE_IMAGE_NAME` | (from flavor) | Filename | Cloud image filename |
 | `FORWARD_PORTS` | (none) | Comma-separated port specs | Extra ports to forward (per-project) |
 | `CLAUDE_ARGS` | `--dangerously-skip-permissions` | Free-form string | Args passed to `claude` inside the VM |
+| `REBASE_BACKUP_PATHS` | (none) | Comma-separated guest paths | Extra paths preserved through `rebase` (see the rebase section) |
 
 ### Priority
 
@@ -255,6 +264,7 @@ defaults < config file < environment variables
 | `BASE_IMAGE_NAME` | Override cloud image filename |
 | `FORWARD_PORTS` | Extra port forwards (see Port Forwarding below) |
 | `CLAUDE_ARGS` | Override args passed to `claude` (default: `--dangerously-skip-permissions`) |
+| `REBASE_BACKUP_PATHS` | Override extra paths preserved through `rebase` |
 | `CLAUDE_VM_VERBOSE` | Set to `true` to show all output (no spinner) |
 | `CLAUDE_VM_QUIET` | Set to `true` to suppress spinner |
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -165,7 +165,10 @@ build_base_image() {
 check_build_prerequisites() {
     local missing=()
 
-    for cmd in qemu-system-x86_64 qemu-img curl; do
+    # jq parses `qemu-img info --output=json` when validating the provisioned
+    # image — without it the build fails at the very end with a misleading
+    # "image is suspiciously small" error.
+    for cmd in qemu-system-x86_64 qemu-img curl jq; do
         if ! command -v "$cmd" &>/dev/null; then
             missing+=("$cmd")
         fi
@@ -193,13 +196,13 @@ check_build_prerequisites() {
         echo "ERROR: Missing required tools: ${missing[*]}" >&2
         echo "" >&2
         echo "Install on Arch/CachyOS:" >&2
-        echo "  sudo pacman -S qemu-full cdrtools curl" >&2
+        echo "  sudo pacman -S qemu-full cdrtools curl jq" >&2
         echo "" >&2
         echo "Install on Ubuntu/Debian:" >&2
-        echo "  sudo apt install qemu-system-x86 qemu-utils genisoimage curl" >&2
+        echo "  sudo apt install qemu-system-x86 qemu-utils genisoimage curl jq" >&2
         echo "" >&2
         echo "Install on Fedora:" >&2
-        echo "  sudo dnf install qemu-system-x86 qemu-img genisoimage curl" >&2
+        echo "  sudo dnf install qemu-system-x86 qemu-img genisoimage curl jq" >&2
         return 1
     fi
 
@@ -322,10 +325,34 @@ provision_base_image() {
         return 1
     fi
 
-    # A fully-provisioned base is ~1.5GB+; significantly less means cloud-init
-    # ran but didn't install much.
-    local img_size
-    img_size=$(qemu-img info --output=json "$build_img" | jq -r '.["actual-size"]' 2>/dev/null || echo "0")
+    _verify_provisioned_size "$build_img" "$serial_log" || return $?
+}
+
+# Sanity-check the size of a freshly provisioned image. A fully-provisioned
+# base is ~1.5GB+; significantly less means cloud-init ran but didn't install
+# much.
+#
+# Errors here are not swallowed: a missing jq or an unreadable image used to
+# collapse into a size of 0 and get reported as "suspiciously small", sending
+# people looking for a provisioning bug that didn't exist.
+# Args: $1 = image path, $2 = serial log path (for the error message)
+_verify_provisioned_size() {
+    local build_img="$1" serial_log="${2:-}"
+    local img_size=""
+
+    if ! img_size=$(qemu-img info --output=json "$build_img" | jq -r '.["actual-size"]'); then
+        echo "ERROR: could not read the size of the provisioned image" >&2
+        echo "       image: $build_img" >&2
+        echo "       (qemu-img info | jq failed — see the error above)" >&2
+        return 1
+    fi
+
+    if [[ ! "$img_size" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: unexpected image size from qemu-img info: '$img_size'" >&2
+        echo "       image: $build_img" >&2
+        return 1
+    fi
+
     if (( img_size < 500000000 )); then
         echo "ERROR: provisioned image is suspiciously small ($(( img_size / 1048576 ))MB, expected >500MB)" >&2
         echo "       serial log: $serial_log" >&2

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -16,6 +16,7 @@ DEFAULT_FLAVOR="debian"
 DEFAULT_VM_USER="$USER"
 DEFAULT_FORWARD_PORTS=""
 DEFAULT_CLAUDE_ARGS="--dangerously-skip-permissions"
+DEFAULT_REBASE_BACKUP_PATHS=""
 
 # ── Flavor registry ──────────────────────────────────────────────────────────
 # Each flavor defines: image URL, image filename, package manager family
@@ -88,6 +89,7 @@ load_config() {
     local _env_vm_user="${VM_USER:-}"
     local _env_forward_ports="${FORWARD_PORTS:-}"
     local _env_claude_args="${CLAUDE_ARGS:-}"
+    local _env_rebase_backup_paths="${REBASE_BACKUP_PATHS:-}"
 
     # Start with defaults
     VM_RAM="$DEFAULT_RAM"
@@ -97,6 +99,7 @@ load_config() {
     VM_USER="$DEFAULT_VM_USER"
     FORWARD_PORTS="$DEFAULT_FORWARD_PORTS"
     CLAUDE_ARGS="$DEFAULT_CLAUDE_ARGS"
+    REBASE_BACKUP_PATHS="$DEFAULT_REBASE_BACKUP_PATHS"
 
     # Override from config file if it exists
     if [[ -f "$CLAUDE_VM_CONFIG" ]]; then
@@ -112,6 +115,7 @@ load_config() {
     [[ -n "$_env_vm_user" ]] && VM_USER="$_env_vm_user"
     [[ -n "$_env_forward_ports" ]] && FORWARD_PORTS="$_env_forward_ports"
     [[ -n "$_env_claude_args" ]] && CLAUDE_ARGS="$_env_claude_args"
+    [[ -n "$_env_rebase_backup_paths" ]] && REBASE_BACKUP_PATHS="$_env_rebase_backup_paths"
 
     # Derive image URL/name from flavor (explicit overrides still win)
     if is_valid_flavor "$FLAVOR"; then
@@ -149,6 +153,7 @@ show_config() {
     echo "BASE_IMAGE_NAME=\"$BASE_IMAGE_NAME\"  # derived from FLAVOR"
     echo "FORWARD_PORTS=\"$(get_project_forward_ports "$PWD")\"  # per-project"
     echo "CLAUDE_ARGS=\"$CLAUDE_ARGS\""
+    echo "REBASE_BACKUP_PATHS=\"$REBASE_BACKUP_PATHS\""
 }
 
 # Set a config key=value in the config file
@@ -158,10 +163,10 @@ set_config_value() {
 
     # Validate key is a known config option
     case "$key" in
-        FLAVOR|VM_USER|VM_RAM|VM_CPUS|SSH_PORT_BASE|BASE_IMAGE_URL|BASE_IMAGE_NAME|FORWARD_PORTS|CLAUDE_ARGS) ;;
+        FLAVOR|VM_USER|VM_RAM|VM_CPUS|SSH_PORT_BASE|BASE_IMAGE_URL|BASE_IMAGE_NAME|FORWARD_PORTS|CLAUDE_ARGS|REBASE_BACKUP_PATHS) ;;
         *)
             echo "Unknown config key: $key" >&2
-            echo "Valid keys: FLAVOR, VM_USER, VM_RAM, VM_CPUS, SSH_PORT_BASE, BASE_IMAGE_URL, BASE_IMAGE_NAME, FORWARD_PORTS, CLAUDE_ARGS" >&2
+            echo "Valid keys: FLAVOR, VM_USER, VM_RAM, VM_CPUS, SSH_PORT_BASE, BASE_IMAGE_URL, BASE_IMAGE_NAME, FORWARD_PORTS, CLAUDE_ARGS, REBASE_BACKUP_PATHS" >&2
             return 1
             ;;
     esac
@@ -196,6 +201,11 @@ set_config_value() {
         FORWARD_PORTS)
             if [[ -n "$value" ]]; then
                 _validate_forward_ports "$value" || return 1
+            fi
+            ;;
+        REBASE_BACKUP_PATHS)
+            if [[ -n "$value" ]]; then
+                _validate_rebase_backup_paths "$value" || return 1
             fi
             ;;
     esac
@@ -330,6 +340,64 @@ _validate_port() {
         echo "Invalid port number: $port (must be 1-65535)" >&2
         return 1
     fi
+    return 0
+}
+
+# Validate REBASE_BACKUP_PATHS spec string
+# Accepts comma-separated guest paths: absolute (/etc/ssh), home-relative
+# (~/.ssh or .ssh). Entries are interpolated unquoted into SSH command
+# strings during rebase, so the charset is deliberately restrictive.
+_validate_rebase_backup_paths() {
+    local value="$1"
+    local IFS=','
+    local entries
+    read -ra entries <<< "$value"
+
+    local entry norm
+    for entry in "${entries[@]}"; do
+        # Trim surrounding whitespace only — internal spaces must fail the
+        # charset check below (entries reach unquoted SSH command strings)
+        entry="${entry#"${entry%%[![:space:]]*}"}"
+        entry="${entry%"${entry##*[![:space:]]}"}"
+        [[ -z "$entry" ]] && continue
+
+        if ! [[ "$entry" =~ ^[A-Za-z0-9._/~@+-]+$ ]]; then
+            echo "Invalid backup path: $entry (allowed characters: A-Z a-z 0-9 . _ / ~ @ + -)" >&2
+            return 1
+        fi
+        if [[ "$entry" == "/" || "$entry" == "~" || "$entry" == "~/" ]]; then
+            echo "Invalid backup path: $entry (whole root/home not allowed — pick specific paths)" >&2
+            return 1
+        fi
+        if [[ "$entry" == *"~"* && "$entry" != "~/"* ]]; then
+            echo "Invalid backup path: $entry (~ only allowed as leading ~/)" >&2
+            return 1
+        fi
+
+        # Normalize: strip leading ~/ and trailing slashes
+        norm="${entry#\~/}"
+        norm="${norm%/}"
+
+        if [[ "/$norm/" == *"/../"* || "$norm" == ".." ]]; then
+            echo "Invalid backup path: $entry (.. segments not allowed)" >&2
+            return 1
+        fi
+
+        case "$norm" in
+            /proc|/proc/*|/sys|/sys/*|/dev|/dev/*|/run|/run/*|/tmp|/tmp/*|/workspace|/workspace/*)
+                echo "Invalid backup path: $entry (transient or mounted path — not restorable)" >&2
+                return 1
+                ;;
+            .claude|.claude/*|.claude.json|.gitconfig|.config/gh|.config/gh/*)
+                echo "Invalid backup path: $entry (already preserved by rebase built-ins)" >&2
+                return 1
+                ;;
+            _abs|_abs/*|.rebase-paths)
+                echo "Invalid backup path: $entry (reserved name)" >&2
+                return 1
+                ;;
+        esac
+    done
     return 0
 }
 

--- a/lib/launch.sh
+++ b/lib/launch.sh
@@ -63,6 +63,22 @@ _build_rsync_cmd() {
     _rsync_cmd=(rsync -az --no-perms --no-owner --no-group -e "$ssh_opts")
 }
 
+# Build rsync command that runs as root on the guest and preserves
+# permissions/ownership. Used for REBASE_BACKUP_PATHS entries (e.g. /etc,
+# ~/.ssh) where root-only files and exact modes matter. --fake-super stashes
+# root ownership in xattrs on the unprivileged host side and replays it as
+# real attributes when pushed back.
+# Sets: _rsync_sudo_cmd array (caller uses it)
+_build_rsync_sudo_cmd() {
+    local port="$1"
+    local ssh_key="$CLAUDE_VM_DIR/keys/id_ed25519"
+    local ssh_opts="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p $port"
+    if [[ -f "$ssh_key" ]]; then
+        ssh_opts="ssh -i $ssh_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p $port"
+    fi
+    _rsync_sudo_cmd=(rsync -az --fake-super --rsync-path="sudo rsync" -e "$ssh_opts")
+}
+
 # Sync host config into the guest VM
 # Syncs: ~/.claude/, ~/.claude.json, ~/.gitconfig, ~/.config/gh/
 # Uses rsync for incremental transfer (only changed files after first launch)

--- a/lib/launch.sh
+++ b/lib/launch.sh
@@ -419,6 +419,8 @@ start_virtiofsd() {
         return 1
     fi
 
+    _check_virtiofsd_idmap "$virtiofsd_bin" || return 1
+
     # Start virtiofsd in background
     "$virtiofsd_bin" \
         --socket-path="$sock_path" \
@@ -430,17 +432,96 @@ start_virtiofsd() {
     local vfs_pid=$!
     echo "$vfs_pid" > "$run_dir/virtiofsd.pid"
 
-    # Wait for socket to appear
+    # Wait for the socket, but watch the process while doing it. virtiofsd
+    # binds the socket before it finishes sandbox setup, so the socket file
+    # existing is not proof of a live listener — a daemon that dies during
+    # setup leaves the file behind and QEMU reports it, several steps later,
+    # as "Failed to connect ...: Connection refused".
     local waited=0
-    while [[ ! -S "$sock_path" ]] && (( waited < 5 )); do
-        sleep 0.2
+    while (( waited < 50 )); do
+        if ! _pid_alive "$vfs_pid"; then
+            _virtiofsd_failed "$run_dir" "virtiofsd exited during startup"
+            return 1
+        fi
+        if [[ -S "$sock_path" ]]; then
+            break
+        fi
+        sleep 0.1
         (( waited++ )) || true
     done
 
     if [[ ! -S "$sock_path" ]]; then
-        echo "ERROR: virtiofsd failed to start. Check $run_dir/virtiofsd.log" >&2
+        kill "$vfs_pid" 2>/dev/null || true
+        _virtiofsd_failed "$run_dir" "virtiofsd did not create its socket within 5s"
         return 1
     fi
+
+    # Socket is there — confirm the daemon survived binding it. Anything that
+    # kills virtiofsd after the bind (namespace setup, permissions on the
+    # shared dir) lands here instead of surfacing as a QEMU chardev error.
+    if ! _pid_alive "$vfs_pid"; then
+        _virtiofsd_failed "$run_dir" "virtiofsd exited after creating its socket"
+        return 1
+    fi
+}
+
+# True while $1 is a running process. Read the state from /proc rather than
+# using `kill -0`: virtiofsd is our own background child, so between its exit
+# and the shell reaping it there is a window where it is a zombie that still
+# answers signals.
+_pid_alive() {
+    local pid="$1" rest state
+    [[ -r "/proc/$pid/stat" ]] || return 1
+    read -r _ rest < "/proc/$pid/stat" || return 1
+    state="${rest##*) }"      # strip through the comm field, which may hold spaces
+    state="${state%% *}"
+    [[ "$state" != "Z" && "$state" != "X" ]]
+}
+
+# Rust virtiofsd runs with --sandbox=namespace by default and shells out to
+# newuidmap/newgidmap to build its unprivileged user namespace. On Debian and
+# Ubuntu those live in the separate `uidmap` package, which is not installed
+# by default; without them virtiofsd dies at startup.
+# Args: $1 = virtiofsd binary path
+_check_virtiofsd_idmap() {
+    local virtiofsd_bin="$1"
+    local missing=()
+    local cmd
+
+    # Root doesn't need the setuid helpers, and the legacy C daemon shipped as
+    # qemu's virtiofsd doesn't use them at all.
+    if (( EUID == 0 )) || [[ "$virtiofsd_bin" == */qemu/virtiofsd ]]; then
+        return 0
+    fi
+
+    for cmd in newuidmap newgidmap; do
+        command -v "$cmd" &>/dev/null || missing+=("$cmd")
+    done
+    if (( ${#missing[@]} == 0 )); then
+        return 0
+    fi
+
+    echo "ERROR: virtiofsd needs ${missing[*]} to set up its user namespace." >&2
+    echo "  Ubuntu/Debian: sudo apt install uidmap" >&2
+    echo "  Fedora:        sudo dnf install shadow-utils" >&2
+    echo "  Arch/CachyOS:  provided by the base 'shadow' package" >&2
+    return 1
+}
+
+# Report a virtiofsd startup failure. The cause is only ever in virtiofsd's own
+# log, so dump its tail — before the summary line, because ui_phase surfaces
+# only the last few lines of the launch log and the fix should be what's left.
+# Args: $1 = run_dir, $2 = message
+_virtiofsd_failed() {
+    local run_dir="$1" msg="$2"
+    local log="$run_dir/virtiofsd.log"
+
+    if [[ -s "$log" ]]; then
+        echo "  virtiofsd log ($log):"
+        tail -10 "$log" | sed 's/^/  | /'
+    fi
+
+    echo "ERROR: $msg — see $log" >&2
 }
 
 # Diagnostics dump used when `wait_for_ssh` times out. Surfaces what the guest

--- a/lib/rebase.sh
+++ b/lib/rebase.sh
@@ -85,6 +85,52 @@ _safe_rsync() {
     (( rc == 0 || rc == 11 || rc == 23 || rc == 24 ))
 }
 
+# Echo normalized REBASE_BACKUP_PATHS entries, one per line.
+# Normalization: split on commas, strip whitespace and trailing slashes,
+# strip a leading ~/ (home-relative entries stay relative, absolute keep /).
+_rebase_user_paths() {
+    local IFS=','
+    local entries entry
+    read -ra entries <<< "${REBASE_BACKUP_PATHS:-}"
+    for entry in "${entries[@]}"; do
+        entry="${entry#"${entry%%[![:space:]]*}"}"
+        entry="${entry%"${entry##*[![:space:]]}"}"
+        [[ -z "$entry" ]] && continue
+        entry="${entry#\~/}"
+        entry="${entry%/}"
+        [[ -z "$entry" ]] && continue
+        echo "$entry"
+    done
+}
+
+# Map a normalized user path to its location inside the backup dir.
+# Absolute paths go under the reserved _abs/ subtree so they can't collide
+# with home-relative entries.
+_backup_rel_path() {
+    local upath="$1"
+    if [[ "$upath" == /* ]]; then
+        echo "_abs${upath}"
+    else
+        echo "$upath"
+    fi
+}
+
+# Human-readable list of everything rebase preserves (builtins + user paths).
+_rebase_preserved_desc() {
+    local desc="" path upath
+    for path in "${_REBASE_GUEST_PATHS[@]}"; do
+        desc+="${desc:+, }~/$path"
+    done
+    while IFS= read -r upath; do
+        if [[ "$upath" == /* ]]; then
+            desc+="${desc:+, }$upath"
+        else
+            desc+="${desc:+, }~/$upath"
+        fi
+    done < <(_rebase_user_paths)
+    echo "$desc"
+}
+
 # ── Extraction QEMU args ────────────────────────────────────────────────────
 
 # Minimal QEMU arg set for extraction VMs — no virtiofs (workspace.mount uses
@@ -200,12 +246,48 @@ _extract_one_vm() {
             || (( ++rsync_fail ))
     done
 
+    # User-configured paths (REBASE_BACKUP_PATHS): synced as root with
+    # perms/ownership preserved. Successfully extracted paths are recorded
+    # in a manifest so restore doesn't depend on the live config value.
+    _build_rsync_sudo_cmd "$ssh_port"
+    local upath guest_path
+    while IFS= read -r upath; do
+        if [[ "$upath" == /* ]]; then
+            guest_path="$upath"
+        else
+            guest_path="~/$upath"
+        fi
+        # sudo probe — root-only paths are invisible to a plain test
+        if ! "${_ssh_cmd[@]}" "sudo test -e $guest_path" 2>/dev/null; then
+            continue
+        fi
+        dest="$backup_dir/$(_backup_rel_path "$upath")"
+        if "${_ssh_cmd[@]}" "sudo test -d $guest_path" 2>/dev/null; then
+            mkdir -p "$dest"
+            if ! _safe_rsync "$log_file" "${_rsync_sudo_cmd[@]}" \
+                "$VM_USER@localhost:$guest_path/" "$dest/"; then
+                (( ++rsync_fail ))
+                continue
+            fi
+        else
+            mkdir -p "$(dirname "$dest")"
+            if ! _safe_rsync "$log_file" "${_rsync_sudo_cmd[@]}" \
+                "$VM_USER@localhost:$guest_path" "$dest"; then
+                (( ++rsync_fail ))
+                continue
+            fi
+        fi
+        echo "$upath" >> "$backup_dir/.rebase-paths"
+    done < <(_rebase_user_paths)
+
     _fast_shutdown "$run_dir"
     _cleanup_runtime "$run_dir"
 
-    # Empty backup dir → no-op restore later; drop it.
-    if [[ -d "$backup_dir" ]] && [[ -z "$(ls -A "$backup_dir" 2>/dev/null)" ]]; then
-        rmdir "$backup_dir" 2>/dev/null || true
+    # Backup with no actual payload (empty dirs and the manifest don't count)
+    # → no-op restore later; drop it.
+    if [[ -d "$backup_dir" ]] && \
+       [[ -z "$(find "$backup_dir" ! -type d ! -name .rebase-paths -print -quit 2>/dev/null)" ]]; then
+        rm -rf "$backup_dir"
     fi
 
     if (( rsync_fail > 0 )); then
@@ -252,6 +334,34 @@ _restore_one_vm() {
         fi
     done
 
+    # User-configured paths recorded at extraction time. Pushed as root with
+    # perms/ownership preserved, as an overlay (no --delete) so files the
+    # fresh image ships that aren't in the backup survive.
+    if [[ -f "$backup_dir/.rebase-paths" ]]; then
+        _build_rsync_sudo_cmd "$ssh_port"
+        local upath guest_path
+        while IFS= read -r upath; do
+            [[ -z "$upath" ]] && continue
+            if [[ "$upath" == /* ]]; then
+                guest_path="$upath"
+            else
+                guest_path="~/$upath"
+            fi
+            src="$backup_dir/$(_backup_rel_path "$upath")"
+            if [[ -d "$src" ]]; then
+                "${_ssh_cmd[@]}" "sudo mkdir -p $guest_path" 2>>"$restore_log" || true
+                if ! _safe_rsync "$restore_log" "${_rsync_sudo_cmd[@]}" "$src/" "$VM_USER@localhost:$guest_path/"; then
+                    ui_warn "restore: failed to sync $upath (see $restore_log)"
+                fi
+            elif [[ -f "$src" ]]; then
+                "${_ssh_cmd[@]}" "sudo mkdir -p $(dirname "$guest_path")" 2>>"$restore_log" || true
+                if ! _safe_rsync "$restore_log" "${_rsync_sudo_cmd[@]}" "$src" "$VM_USER@localhost:$guest_path"; then
+                    ui_warn "restore: failed to sync $upath (see $restore_log)"
+                fi
+            fi
+        done < "$backup_dir/.rebase-paths"
+    fi
+
     rm -rf "$backup_dir"
 }
 
@@ -270,7 +380,12 @@ Usage: claude-vm rebase [--yes] [--force]
 
 Rebuild the base image from the latest cloud image while preserving each
 project VM's persistent state (~/.claude/, ~/.claude.json, ~/.gitconfig,
-~/.config/gh/). All other guest-side changes are discarded.
+~/.config/gh/), plus any extra guest paths configured via:
+
+  claude-vm config set REBASE_BACKUP_PATHS "/etc/ssh,~/.ssh"
+
+Extra paths are synced with sudo rsync and keep permissions/ownership.
+All other guest-side changes are discarded.
 
 Options:
   --yes, -y    Skip the confirmation prompt
@@ -311,7 +426,7 @@ EOF
     ui_info "  3. Rebuild the base image from the latest cloud image"
     ui_info "  4. Restore extracted state on next launch"
     ui_info ""
-    ui_info "VM-side state preserved: ~/.claude/, ~/.claude.json, ~/.gitconfig, ~/.config/gh/"
+    ui_info "VM-side state preserved: $(_rebase_preserved_desc)"
     ui_info "Everything else in each VM will be lost."
     ui_info ""
     local proj

--- a/tests/test_build.sh
+++ b/tests/test_build.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test_build.sh — Unit tests for build.sh host-prerequisite and image checks
+#
+# Tests:
+# 1. check_build_prerequisites reports jq when it is missing
+# 2. check_build_prerequisites passes when every tool is present
+# 3. _verify_provisioned_size accepts a full-size image
+# 4. _verify_provisioned_size rejects an undersized image
+# 5. A missing jq is reported as such, not as "suspiciously small" (issue #7)
+# 6. Non-numeric qemu-img output is reported as such, not as size 0
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$TEST_SCRIPT_DIR")"
+
+source "$REPO_DIR/lib/build.sh"
+
+set +euo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { echo "  PASS: $1"; (( TESTS_PASSED++ )); (( TESTS_RUN++ )); }
+fail() { echo "  FAIL: $1"; (( TESTS_FAILED++ )); (( TESTS_RUN++ )); }
+
+FAKE_BIN=""
+
+# Build a PATH containing only stub tools, so tests are independent of what
+# happens to be installed on the machine running them.
+# Args: tool names to stub out
+setup_fake_bin() {
+    FAKE_BIN="$(mktemp -d)"
+    local tool
+    for tool in "$@"; do
+        printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/$tool"
+        chmod +x "$FAKE_BIN/$tool"
+    done
+}
+
+teardown_fake_bin() {
+    [[ -n "$FAKE_BIN" ]] && rm -rf "$FAKE_BIN"
+    FAKE_BIN=""
+}
+
+# Stub qemu-img so `info --output=json` prints a chosen payload
+# Args: $1 = JSON to emit
+fake_qemu_img() {
+    cat > "$FAKE_BIN/qemu-img" <<EOF
+#!/usr/bin/env bash
+cat <<'JSON'
+$1
+JSON
+EOF
+    chmod +x "$FAKE_BIN/qemu-img"
+}
+
+# ── Test 1: jq is a declared prerequisite ────────────────────────────────────
+echo "--- Test 1: check_build_prerequisites reports missing jq ---"
+setup_fake_bin qemu-system-x86_64 qemu-img curl genisoimage
+
+output="$(PATH="$FAKE_BIN" check_build_prerequisites 2>&1)"
+rc=$?
+
+if (( rc != 0 )) && [[ "$output" == *jq* ]]; then
+    pass "missing jq fails the prerequisite check and is named"
+else
+    fail "missing jq should fail the check (rc=$rc): $output"
+fi
+
+teardown_fake_bin
+
+# ── Test 2: complete toolchain passes ────────────────────────────────────────
+echo "--- Test 2: check_build_prerequisites passes with all tools ---"
+setup_fake_bin qemu-system-x86_64 qemu-img curl genisoimage jq
+
+output="$(PATH="$FAKE_BIN" check_build_prerequisites 2>&1)"
+rc=$?
+
+if (( rc == 0 )); then
+    pass "complete toolchain satisfies the prerequisite check"
+else
+    fail "complete toolchain should pass (rc=$rc): $output"
+fi
+
+teardown_fake_bin
+
+# ── Test 3: full-size image is accepted ──────────────────────────────────────
+echo "--- Test 3: _verify_provisioned_size accepts a 1.5GB image ---"
+if ! command -v jq &>/dev/null; then
+    echo "  SKIP: jq not installed"
+else
+    setup_fake_bin
+    fake_qemu_img '{"actual-size": 1610612736}'
+
+    output="$(PATH="$FAKE_BIN:$PATH" bash -c '
+        set -o pipefail
+        source "'"$REPO_DIR"'/lib/build.sh"
+        _verify_provisioned_size /tmp/fake.qcow2 /tmp/serial.log' 2>&1)"
+    rc=$?
+
+    if (( rc == 0 )); then
+        pass "1.5GB image passes the size check"
+    else
+        fail "1.5GB image should pass (rc=$rc): $output"
+    fi
+
+    teardown_fake_bin
+fi
+
+# ── Test 4: undersized image is rejected ─────────────────────────────────────
+echo "--- Test 4: _verify_provisioned_size rejects a 10MB image ---"
+if ! command -v jq &>/dev/null; then
+    echo "  SKIP: jq not installed"
+else
+    setup_fake_bin
+    fake_qemu_img '{"actual-size": 10485760}'
+
+    output="$(PATH="$FAKE_BIN:$PATH" bash -c '
+        set -o pipefail
+        source "'"$REPO_DIR"'/lib/build.sh"
+        _verify_provisioned_size /tmp/fake.qcow2 /tmp/serial.log' 2>&1)"
+    rc=$?
+
+    if (( rc != 0 )) && [[ "$output" == *"suspiciously small"* ]]; then
+        pass "10MB image is rejected as suspiciously small"
+    else
+        fail "10MB image should be rejected (rc=$rc): $output"
+    fi
+
+    teardown_fake_bin
+fi
+
+# ── Test 5: missing jq is not misreported as a small image (issue #7) ────────
+echo "--- Test 5: missing jq is reported as a read failure, not a small image ---"
+setup_fake_bin
+fake_qemu_img '{"actual-size": 1610612736}'
+
+# PATH holds only the stubs — no jq anywhere.
+output="$(PATH="$FAKE_BIN" bash -c '
+    set -o pipefail
+    source "'"$REPO_DIR"'/lib/build.sh"
+    _verify_provisioned_size /tmp/fake.qcow2 /tmp/serial.log' 2>&1)"
+rc=$?
+
+if (( rc != 0 )) && [[ "$output" != *"suspiciously small"* ]]; then
+    pass "missing jq does not masquerade as a suspiciously small image"
+else
+    fail "missing jq should not report a small image (rc=$rc): $output"
+fi
+
+teardown_fake_bin
+
+# ── Test 6: non-numeric size is reported as such ─────────────────────────────
+echo "--- Test 6: unparseable qemu-img output is reported as unexpected ---"
+if ! command -v jq &>/dev/null; then
+    echo "  SKIP: jq not installed"
+else
+    setup_fake_bin
+    fake_qemu_img '{"format": "qcow2"}'   # no actual-size key -> jq prints "null"
+
+    output="$(PATH="$FAKE_BIN:$PATH" bash -c '
+        set -o pipefail
+        source "'"$REPO_DIR"'/lib/build.sh"
+        _verify_provisioned_size /tmp/fake.qcow2 /tmp/serial.log' 2>&1)"
+    rc=$?
+
+    if (( rc != 0 )) && [[ "$output" == *"unexpected image size"* ]]; then
+        pass "missing actual-size key reports an unexpected size"
+    else
+        fail "missing actual-size should report unexpected size (rc=$rc): $output"
+    fi
+
+    teardown_fake_bin
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+(( TESTS_FAILED > 0 )) && exit 1 || exit 0

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -23,7 +23,7 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 
 # Helper: reset config state for each test
 _reset_config_env() {
-    unset VM_RAM VM_CPUS SSH_PORT_BASE BASE_IMAGE_URL BASE_IMAGE_NAME CLAUDE_ARGS 2>/dev/null || true
+    unset VM_RAM VM_CPUS SSH_PORT_BASE BASE_IMAGE_URL BASE_IMAGE_NAME CLAUDE_ARGS REBASE_BACKUP_PATHS 2>/dev/null || true
 }
 
 # ─── Tests ────────────────────────────────────────────────────────────────────
@@ -570,6 +570,108 @@ test_set_config_claude_args() {
     unset CLAUDE_ARGS 2>/dev/null || true
 }
 
+test_default_rebase_backup_paths() {
+    _reset_config_env
+    export CLAUDE_VM_DIR="$TEST_DIR/test-rbp-default"
+    export CLAUDE_VM_CONFIG="$CLAUDE_VM_DIR/config"
+
+    source "$PROJECT_DIR/lib/config.sh"
+    load_config
+
+    if [[ "$REBASE_BACKUP_PATHS" == "" ]]; then
+        pass "default REBASE_BACKUP_PATHS is empty"
+    else
+        fail "default REBASE_BACKUP_PATHS" "expected empty, got '$REBASE_BACKUP_PATHS'"
+    fi
+    _reset_config_env
+}
+
+test_set_config_rebase_backup_paths() {
+    _reset_config_env
+    export CLAUDE_VM_DIR="$TEST_DIR/test-set-rbp"
+    export CLAUDE_VM_CONFIG="$CLAUDE_VM_DIR/config"
+
+    source "$PROJECT_DIR/lib/config.sh"
+
+    if set_config_value "REBASE_BACKUP_PATHS" "/etc/ssh,~/.ssh,.config/foo" >/dev/null 2>&1; then
+        pass "set_config_value accepts valid path list"
+    else
+        fail "set REBASE_BACKUP_PATHS" "rejected /etc/ssh,~/.ssh,.config/foo"
+    fi
+
+    if grep -q 'REBASE_BACKUP_PATHS="/etc/ssh,~/.ssh,.config/foo"' "$CLAUDE_VM_CONFIG"; then
+        pass "value persisted to config file"
+    else
+        fail "REBASE_BACKUP_PATHS persisted" "value not found in config file"
+    fi
+
+    load_config
+    if [[ "$REBASE_BACKUP_PATHS" == "/etc/ssh,~/.ssh,.config/foo" ]]; then
+        pass "load_config round-trips the value"
+    else
+        fail "REBASE_BACKUP_PATHS round-trip" "got '$REBASE_BACKUP_PATHS'"
+    fi
+
+    if set_config_value "REBASE_BACKUP_PATHS" "" >/dev/null 2>&1; then
+        pass "empty value accepted (clears the list)"
+    else
+        fail "clear REBASE_BACKUP_PATHS" "empty value rejected"
+    fi
+    _reset_config_env
+}
+
+test_rebase_backup_paths_env_override() {
+    _reset_config_env
+    export CLAUDE_VM_DIR="$TEST_DIR/test-rbp-env"
+    export CLAUDE_VM_CONFIG="$CLAUDE_VM_DIR/config"
+
+    mkdir -p "$CLAUDE_VM_DIR"
+    cat > "$CLAUDE_VM_CONFIG" << 'EOF'
+REBASE_BACKUP_PATHS="/etc/ssh"
+EOF
+
+    export REBASE_BACKUP_PATHS="~/.ssh"
+
+    source "$PROJECT_DIR/lib/config.sh"
+    load_config
+
+    if [[ "$REBASE_BACKUP_PATHS" == "~/.ssh" ]]; then
+        pass "env var REBASE_BACKUP_PATHS overrides config file"
+    else
+        fail "env var REBASE_BACKUP_PATHS override" "expected '~/.ssh', got '$REBASE_BACKUP_PATHS'"
+    fi
+    _reset_config_env
+}
+
+test_rebase_backup_paths_validation() {
+    _reset_config_env
+    export CLAUDE_VM_DIR="$TEST_DIR/test-rbp-validate"
+    export CLAUDE_VM_CONFIG="$CLAUDE_VM_DIR/config"
+
+    source "$PROJECT_DIR/lib/config.sh"
+
+    local bad
+    local rejected_all=true
+    for bad in "../evil" "/etc/../root" "/" "~" "~/" "/etc/some dir" ".claude" ".claude/foo" ".config/gh" "_abs/x" ".rebase-paths" "/proc/net" "/tmp/x" "/workspace/x" "foo~bar"; do
+        if set_config_value "REBASE_BACKUP_PATHS" "$bad" 2>/dev/null; then
+            fail "rejects '$bad'" "value was accepted"
+            rejected_all=false
+        fi
+    done
+    $rejected_all && pass "rejects .., root/home, spaces, builtins, reserved names, transient paths"
+
+    local good
+    local accepted_all=true
+    for good in "/etc/ssh" "/etc/hosts" "~/.ssh" ".ssh" ".config/foo" "/opt/tool-1.2_x@host+v" "/etc/ssh/, ~/.ssh"; do
+        if ! set_config_value "REBASE_BACKUP_PATHS" "$good" >/dev/null 2>&1; then
+            fail "accepts '$good'" "value was rejected"
+            accepted_all=false
+        fi
+    done
+    $accepted_all && pass "accepts absolute, home-relative, and mixed lists"
+    _reset_config_env
+}
+
 # ─── Run ──────────────────────────────────────────────────────────────────────
 
 echo "=== claude-vm config tests ==="
@@ -593,6 +695,10 @@ run_test test_claude_args_config_override
 run_test test_claude_args_env_override
 run_test test_cmd_launch_parses_double_dash_args
 run_test test_set_config_claude_args
+run_test test_default_rebase_backup_paths
+run_test test_set_config_rebase_backup_paths
+run_test test_rebase_backup_paths_env_override
+run_test test_rebase_backup_paths_validation
 
 echo ""
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed, ${TESTS_RUN} total"

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -4,11 +4,16 @@
 # Tests:
 # 1. sync_claude_config_to_vm is called on first VM creation (new snapshot)
 # 2. sync_claude_config_to_vm is skipped on subsequent launches (existing snapshot)
+# 3. _pid_alive tracks process liveness (including unreaped children)
+# 4. _check_virtiofsd_idmap requires newuidmap/newgidmap when unprivileged
+# 5. start_virtiofsd fails when virtiofsd dies after binding its socket
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_DIR="$PROJECT_DIR"
 
 source "$PROJECT_DIR/lib/config.sh"
+source "$PROJECT_DIR/lib/launch.sh"
 
 set +euo pipefail
 
@@ -70,6 +75,150 @@ fi
 
 rm -rf "$PROJECT_DIR_TEST"
 teardown_test_env
+
+# ── Test: _pid_alive reports a running process as alive ──────────────────────
+echo "--- Test 3: _pid_alive on a running process ---"
+
+sleep 30 &
+live_pid=$!
+
+if _pid_alive "$live_pid"; then
+    pass "_pid_alive true for a running process"
+else
+    fail "_pid_alive should be true for a running process"
+fi
+
+kill "$live_pid" 2>/dev/null
+
+# ── Test: _pid_alive reports an exited child as dead ─────────────────────────
+# The child is deliberately left unreaped — `kill -0` succeeds on a zombie, so
+# liveness is read from /proc instead.
+echo "--- Test 4: _pid_alive on an exited (unreaped) child ---"
+
+bash -c 'exit 1' &
+dead_pid=$!
+sleep 0.3
+
+if _pid_alive "$dead_pid"; then
+    fail "_pid_alive should be false for an exited child"
+else
+    pass "_pid_alive false for an exited child"
+fi
+
+wait "$dead_pid" 2>/dev/null
+
+# ── Test: virtiofsd id-mapping helpers are required (issue #7) ───────────────
+echo "--- Test 5: _check_virtiofsd_idmap requires newuidmap/newgidmap ---"
+
+FAKE_BIN="$(mktemp -d)"
+
+output="$(PATH="$FAKE_BIN" _check_virtiofsd_idmap /usr/libexec/virtiofsd 2>&1)"
+rc=$?
+
+if (( EUID == 0 )); then
+    echo "  SKIP: running as root (the helpers are only needed unprivileged)"
+elif (( rc != 0 )) && [[ "$output" == *uidmap* ]]; then
+    pass "missing newuidmap/newgidmap fails with an install hint"
+else
+    fail "missing newuidmap/newgidmap should fail (rc=$rc): $output"
+fi
+
+# Present in PATH -> check passes
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/newuidmap"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/newgidmap"
+chmod +x "$FAKE_BIN/newuidmap" "$FAKE_BIN/newgidmap"
+
+if PATH="$FAKE_BIN" _check_virtiofsd_idmap /usr/libexec/virtiofsd 2>/dev/null; then
+    pass "newuidmap/newgidmap present satisfies the check"
+else
+    fail "newuidmap/newgidmap present should satisfy the check"
+fi
+
+# The legacy C daemon doesn't use the helpers — don't demand them
+rm -f "$FAKE_BIN/newuidmap" "$FAKE_BIN/newgidmap"
+
+if PATH="$FAKE_BIN" _check_virtiofsd_idmap /usr/lib/qemu/virtiofsd 2>/dev/null; then
+    pass "legacy qemu virtiofsd skips the id-map check"
+else
+    fail "legacy qemu virtiofsd should skip the id-map check"
+fi
+
+rm -rf "$FAKE_BIN"
+
+# ── Test: start_virtiofsd rejects a daemon that dies after binding ───────────
+# Regression for issue #7: virtiofsd binds the socket, then dies during sandbox
+# setup (e.g. no newuidmap). The socket file survives, so an existence-only
+# check passed and the failure surfaced later as a QEMU "Connection refused".
+echo "--- Test 6: start_virtiofsd detects a daemon that dies after binding ---"
+
+if ! command -v python3 &>/dev/null; then
+    echo "  SKIP: python3 needed to create a unix socket"
+else
+    setup_test_env
+    FAKE_BIN="$(mktemp -d)"
+    VFS_PROJECT="$(mktemp -d)"
+    VFS_RUN="$TEST_VM_DIR/run/fake"
+    mkdir -p "$VFS_RUN"
+
+    # Stub the id-map helpers so this test exercises liveness, not test 5
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/newuidmap"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/newgidmap"
+    chmod +x "$FAKE_BIN/newuidmap" "$FAKE_BIN/newgidmap"
+
+    # Fake virtiofsd: bind the socket, leave the file behind, then die
+    cat > "$FAKE_BIN/virtiofsd" <<'FAKE'
+#!/usr/bin/env bash
+sock=""
+for arg in "$@"; do
+    case "$arg" in --socket-path=*) sock="${arg#--socket-path=}" ;; esac
+done
+python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.listen(1)' "$sock"
+echo "fake virtiofsd: simulated crash during sandbox setup" >&2
+exit 1
+FAKE
+    chmod +x "$FAKE_BIN/virtiofsd"
+
+    output="$(PATH="$FAKE_BIN:$PATH" start_virtiofsd "$VFS_PROJECT" "$VFS_RUN/virtiofs.sock" "$VFS_RUN" 2>&1)"
+    rc=$?
+
+    if (( rc != 0 )); then
+        pass "start_virtiofsd fails when the daemon dies after binding"
+    else
+        fail "start_virtiofsd should fail when the daemon dies (rc=$rc): $output"
+    fi
+
+    if [[ "$output" == *"simulated crash"* ]]; then
+        pass "start_virtiofsd surfaces the virtiofsd log on failure"
+    else
+        fail "start_virtiofsd should surface the virtiofsd log: $output"
+    fi
+
+    # ── A daemon that stays up is accepted ──────────────────────────────────
+    echo "--- Test 7: start_virtiofsd accepts a live daemon ---"
+    cat > "$FAKE_BIN/virtiofsd" <<'FAKE'
+#!/usr/bin/env bash
+sock=""
+for arg in "$@"; do
+    case "$arg" in --socket-path=*) sock="${arg#--socket-path=}" ;; esac
+done
+exec python3 -c 'import socket,sys,time; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.listen(1); time.sleep(30)' "$sock"
+FAKE
+    chmod +x "$FAKE_BIN/virtiofsd"
+
+    rm -f "$VFS_RUN/virtiofs.sock"
+    output="$(PATH="$FAKE_BIN:$PATH" start_virtiofsd "$VFS_PROJECT" "$VFS_RUN/virtiofs.sock" "$VFS_RUN" 2>&1)"
+    rc=$?
+
+    if (( rc == 0 )); then
+        pass "start_virtiofsd succeeds when the daemon stays alive"
+    else
+        fail "start_virtiofsd should succeed with a live daemon (rc=$rc): $output"
+    fi
+
+    [[ -f "$VFS_RUN/virtiofsd.pid" ]] && kill "$(cat "$VFS_RUN/virtiofsd.pid")" 2>/dev/null
+    rm -rf "$FAKE_BIN" "$VFS_PROJECT"
+    teardown_test_env
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test_rebase.sh
+++ b/tests/test_rebase.sh
@@ -523,6 +523,7 @@ test_restore_consumes_backup() {
     # Stub out the ssh/rsync helpers so _restore_one_vm doesn't shell out
     _build_ssh_cmd()   { _ssh_cmd=(true); }
     _build_rsync_cmd() { _rsync_cmd=(true); }
+    _build_rsync_sudo_cmd() { _rsync_sudo_cmd=(true); }
 
     # A: no backup directory → no-op, returns 0
     if _restore_one_vm "$project" 10022; then
@@ -542,6 +543,207 @@ test_restore_consumes_backup() {
         pass "backup dir removed after restore"
     else
         fail "backup consumed" "directory still present at $bd"
+    fi
+
+    teardown_test_env
+}
+
+# ── 16: _rebase_user_paths normalizes REBASE_BACKUP_PATHS entries ───────────
+
+test_rebase_user_paths_normalization() {
+    echo "--- Test 16: _rebase_user_paths normalization ---"
+    setup_test_env
+
+    REBASE_BACKUP_PATHS="~/.ssh, /etc/,foo/, ,"
+    local output expected
+    output="$(_rebase_user_paths)"
+    expected="$(printf '%s\n%s\n%s' ".ssh" "/etc" "foo")"
+
+    if [[ "$output" == "$expected" ]]; then
+        pass "entries trimmed, ~/ and trailing slashes stripped, empties skipped"
+    else
+        fail "_rebase_user_paths" "expected '$expected', got '$output'"
+    fi
+
+    REBASE_BACKUP_PATHS=""
+    output="$(_rebase_user_paths)"
+    if [[ -z "$output" ]]; then
+        pass "empty config → no output"
+    else
+        fail "_rebase_user_paths empty" "got '$output'"
+    fi
+
+    teardown_test_env
+}
+
+# ── 17: _backup_rel_path maps absolute paths under _abs/ ────────────────────
+
+test_backup_rel_path() {
+    echo "--- Test 17: _backup_rel_path layout ---"
+    setup_test_env
+
+    local ok=true
+    [[ "$(_backup_rel_path "/etc")" == "_abs/etc" ]]             || { fail "_backup_rel_path /etc" "got $(_backup_rel_path "/etc")"; ok=false; }
+    [[ "$(_backup_rel_path "/etc/hosts")" == "_abs/etc/hosts" ]] || { fail "_backup_rel_path /etc/hosts" "got $(_backup_rel_path "/etc/hosts")"; ok=false; }
+    [[ "$(_backup_rel_path ".ssh")" == ".ssh" ]]                 || { fail "_backup_rel_path .ssh" "got $(_backup_rel_path ".ssh")"; ok=false; }
+
+    $ok && pass "absolute → _abs/<path>, home-relative unchanged"
+
+    teardown_test_env
+}
+
+# ── 18: _build_rsync_sudo_cmd runs as root and preserves perms ───────────────
+
+test_build_rsync_sudo_cmd() {
+    echo "--- Test 18: _build_rsync_sudo_cmd flags ---"
+    setup_test_env
+
+    _build_rsync_sudo_cmd 10022
+
+    local has_sudo=false has_fake_super=false strips_perms=false arg
+    for arg in "${_rsync_sudo_cmd[@]}"; do
+        [[ "$arg" == "--rsync-path=sudo rsync" ]] && has_sudo=true
+        [[ "$arg" == "--fake-super" ]]            && has_fake_super=true
+        [[ "$arg" == "--no-perms" || "$arg" == "--no-owner" || "$arg" == "--no-group" ]] && strips_perms=true
+    done
+
+    if $has_sudo && $has_fake_super && ! $strips_perms; then
+        pass "sudo rsync-path + --fake-super, no perms-stripping flags"
+    else
+        fail "_build_rsync_sudo_cmd" "sudo=$has_sudo fake_super=$has_fake_super strips_perms=$strips_perms"
+    fi
+
+    teardown_test_env
+}
+
+# ── 19: _rebase_preserved_desc lists builtins + user paths ──────────────────
+
+test_rebase_preserved_desc() {
+    echo "--- Test 19: _rebase_preserved_desc ---"
+    setup_test_env
+
+    REBASE_BACKUP_PATHS="/etc/ssh,~/.ssh"
+    local desc
+    desc="$(_rebase_preserved_desc)"
+
+    if [[ "$desc" == *"~/.claude/"* && "$desc" == *"~/.gitconfig"* \
+          && "$desc" == *"/etc/ssh"* && "$desc" == *"~/.ssh"* ]]; then
+        pass "description includes builtins and user paths"
+    else
+        fail "_rebase_preserved_desc" "got '$desc'"
+    fi
+
+    teardown_test_env
+}
+
+# ── 20: _restore_one_vm pushes manifest paths via sudo rsync ────────────────
+
+test_restore_manifest_paths() {
+    echo "--- Test 20: manifest restore uses sudo rsync + correct destinations ---"
+    setup_test_env
+
+    local project="/tmp/proj-manifest-restore-$$"
+    local bd cap sshcap
+    bd="$(project_backup_dir "$project")"
+    cap="$TEST_VM_DIR/rsync-capture"
+    sshcap="$TEST_VM_DIR/ssh-capture"
+    : > "$cap"; : > "$sshcap"
+
+    mkdir -p "$bd/.ssh" "$bd/_abs/etc"
+    echo "key"   > "$bd/.ssh/id_ed25519"
+    echo "hosts" > "$bd/_abs/etc/hosts"
+    printf '%s\n%s\n' ".ssh" "/etc/hosts" > "$bd/.rebase-paths"
+
+    fake_ssh()        { echo "$*" >> "$sshcap"; return 0; }
+    fake_rsync()      { echo "plain $*" >> "$cap"; return 0; }
+    fake_rsync_sudo() { echo "sudo $*"  >> "$cap"; return 0; }
+    _build_ssh_cmd()        { _ssh_cmd=(fake_ssh); }
+    _build_rsync_cmd()      { _rsync_cmd=(fake_rsync); }
+    _build_rsync_sudo_cmd() { _rsync_sudo_cmd=(fake_rsync_sudo); }
+
+    _restore_one_vm "$project" 10022 >/dev/null 2>&1
+
+    local ok=true
+    grep -q "sudo $bd/.ssh/ $VM_USER@localhost:~/.ssh/" "$cap" \
+        || { fail "dir restore" "no sudo rsync push of .ssh/ ($(cat "$cap"))"; ok=false; }
+    grep -q "sudo $bd/_abs/etc/hosts $VM_USER@localhost:/etc/hosts" "$cap" \
+        || { fail "file restore" "no sudo rsync push of /etc/hosts ($(cat "$cap"))"; ok=false; }
+    grep -q "sudo mkdir -p ~/.ssh" "$sshcap" \
+        || { fail "dir mkdir" "no sudo mkdir -p ~/.ssh"; ok=false; }
+    grep -q "sudo mkdir -p /etc" "$sshcap" \
+        || { fail "file mkdir" "no sudo mkdir -p /etc"; ok=false; }
+    grep -q "^plain .*_abs" "$cap" \
+        && { fail "sudo separation" "user path went through the unprivileged rsync"; ok=false; }
+    [[ -d "$bd" ]] \
+        && { fail "backup consumed" "directory still present"; ok=false; }
+
+    $ok && pass "manifest paths pushed via sudo rsync to ~/.ssh and /etc/hosts, backup consumed"
+
+    teardown_test_env
+}
+
+# ── 21: extraction records manifest and drops bare-manifest backups ─────────
+
+test_extract_user_paths_manifest() {
+    echo "--- Test 21: extraction manifest + empty-backup cleanup ---"
+    setup_test_env
+
+    local project="/tmp/proj-extract-manifest-$$"
+    register_project "$project"
+    local bd
+    bd="$(project_backup_dir "$project")"
+
+    # Stub everything around the copy loops so the real _extract_one_vm runs
+    qemu-system-x86_64() { return 0; }
+    wait_for_ssh()       { return 0; }
+    _detect_accel()      { echo "tcg"; }
+    find_available_port() { echo 29022; }
+    _fast_shutdown()     { return 0; }
+    _cleanup_runtime()   { return 0; }
+
+    # Guest state: /etc exists (dir), ~/.ssh missing; builtins missing
+    fake_ssh() {
+        case "${*: -1}" in
+            "sudo test -e /etc"|"sudo test -d /etc") return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    fake_rsync_sudo() { echo "payload" > "${@: -1}/passwd"; return 0; }
+    _build_ssh_cmd()        { _ssh_cmd=(fake_ssh); }
+    _build_rsync_cmd()      { _rsync_cmd=(true); }
+    _build_rsync_sudo_cmd() { _rsync_sudo_cmd=(fake_rsync_sudo); }
+
+    REBASE_BACKUP_PATHS="/etc,~/.ssh"
+    _extract_one_vm "$project" >/dev/null 2>&1
+
+    local ok=true
+    [[ -f "$bd/_abs/etc/passwd" ]] \
+        || { fail "extract payload" "missing $bd/_abs/etc/passwd"; ok=false; }
+    [[ -f "$bd/.rebase-paths" ]] \
+        || { fail "manifest written" "missing .rebase-paths"; ok=false; }
+    if [[ -f "$bd/.rebase-paths" ]]; then
+        grep -qx "/etc" "$bd/.rebase-paths"  || { fail "manifest content" "/etc not recorded"; ok=false; }
+        grep -qx ".ssh" "$bd/.rebase-paths"  && { fail "manifest content" "missing .ssh was recorded"; ok=false; }
+    fi
+    $ok && pass "existing path extracted + recorded, missing path skipped"
+
+    # Bare-manifest backup (file entry whose rsync transferred nothing) → dropped
+    rm -rf "$bd"
+    fake_ssh() {
+        case "${*: -1}" in
+            "sudo test -e /etc/nosuch") return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    fake_rsync_sudo() { return 24; }  # tolerated rc, nothing written
+
+    REBASE_BACKUP_PATHS="/etc/nosuch"
+    _extract_one_vm "$project" >/dev/null 2>&1
+
+    if [[ ! -d "$bd" ]]; then
+        pass "backup containing only the manifest is dropped"
+    else
+        fail "bare-manifest cleanup" "backup dir still present: $(ls -A "$bd")"
     fi
 
     teardown_test_env
@@ -568,6 +770,12 @@ test_cmd_rebase_sidecar_lifecycle
 test_cmd_rebase_aborts_on_failure
 test_cmd_rebase_force_drops_failed
 test_restore_consumes_backup
+test_rebase_user_paths_normalization
+test_backup_rel_path
+test_build_rsync_sudo_cmd
+test_rebase_preserved_desc
+test_restore_manifest_paths
+test_extract_user_paths_manifest
 
 echo ""
 echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed, $TESTS_SKIPPED skipped, $TESTS_RUN total ==="


### PR DESCRIPTION
Two commits.

## `fix(build,launch)`: declare jq/uidmap prereqs, verify virtiofsd is alive

Closes #7 — two first-run failures on Ubuntu, both caused by host dependencies that were required but never declared, and both reported as something else entirely.

**`jq`** parses `qemu-img info --output=json` but was missing from `check_build_prerequisites`. The size validation then swallowed the failure (`2>/dev/null || echo "0"`) and reported the resulting 0 as `provisioned image is suspiciously small (0MB)`, pointing at a provisioning bug that didn't exist. It's now a declared prerequisite, and `_verify_provisioned_size` distinguishes a read failure, a non-numeric result, and a genuinely undersized image.

**`newuidmap`/`newgidmap`** — rust virtiofsd shells out to them for its unprivileged user namespace; on Debian/Ubuntu they ship in the separate `uidmap` package, which isn't installed by default. Without them virtiofsd binds its socket and then dies during sandbox setup. `start_virtiofsd` only checked that the socket *file* existed, so the dead daemon passed and QEMU surfaced it later as `Failed to connect ...: Connection refused`. Now the helpers are checked up front (skipped for root and for the legacy C daemon), and the socket wait watches the process, reading liveness from `/proc` since `kill -0` succeeds on a not-yet-reaped zombie. Failures dump the tail of `virtiofsd.log`.

**Why E2E missed both:** the suite requires `jq` and a working virtiofsd itself and skips when they're absent, so the fixture guarantees the dependency whose absence is the bug. These are covered by unit tests instead: `tests/test_build.sh` is new (6 tests), `tests/test_launch.sh` gains 5 — including a fake virtiofsd that binds its socket and dies, which the old check accepted.

## `feat(rebase)`: add REBASE_BACKUP_PATHS for extra guest paths

Pre-existing work in the tree, included here for the 0.1.2 release. Comma-separated extra guest paths carried through a base rebuild, synced as root with permissions preserved.

`make test-unit` passes (159 assertions). E2E is unchanged and untested here — no KVM in this environment.